### PR TITLE
:sparkles: image.type.external の対応

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,7 +32,7 @@ if (!DATABASE_ID) {
 
 module.exports = {
   images: {
-    domains: ['s3.us-west-2.amazonaws.com'],
+    domains: ['s3.us-west-2.amazonaws.com', 'images.unsplash.com'],
   },
 
   outputFileTracing: false,

--- a/src/lib/notion/client.ts
+++ b/src/lib/notion/client.ts
@@ -294,7 +294,10 @@ export async function getAllBlocksByBlockId(blockId) {
             Caption: item.image.caption.map(_buildRichText),
             Type: item.image.type,
             File: {
-              Url: item.image.file.url,
+              Url:
+                item.image.type === 'external'
+                  ? item.image.external.url
+                  : item.image.file.url,
             },
           }
 


### PR DESCRIPTION
`/image`にて `unsplash`の画像が適用できるのですが、これのtypeが`external`になっていて、画像表示のエラーが発生したので対応しました。

notion上でいうとこちらです。

![2022-02-20 14 10 18](https://user-images.githubusercontent.com/10850034/154829354-07534323-6438-4ebb-ba91-6b53cb7a6238.gif)

