### PR TITLE
Fix code text color

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,6 +10,7 @@
   --accents-2: #3291ff;
   --accents-3: #666;
   --geist-foreground: #000;
+  --geist-success: rgb(15, 95, 244);
 
   --radius: 4px;
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -289,6 +289,8 @@ hr {
 code {
   font-size: 0.9rem;
   background: #f1f1f1;
+  color: #eb5757;
+  padding: 0.25rem;
   border-radius: var(--radius);
   font-family: var(--font-mono);
 }

--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -31,7 +31,10 @@
   line-height: 1.2rem;
   border-radius: var(--radius);
 }
-
+.code pre code {
+  color: var(--fg);
+  padding: 0;
+}
 .gray {
   color: rgba(120, 119, 116, 1);
 }


### PR DESCRIPTION
以下３種類のcodeテキストのpaddingや文字色の修正を行いました。

- Code block の文字色
- 通常のテキストに装飾するcode text
- 他のblock内でテキストを装飾するcode text


  | code block | paragraph block ❌ code Annotation | num list(他) block ❌ code Annotation
-- | -- | -- | --
CSSの適用 | blog-blocksでなくglobal | blog | global
PR #76 | globalのpadding削 | padding追加 | padding無くて変👉今回修正
今回のPR  | blog-blocksが適用されるよう修正__ pagging: 0; | paddingそのまま  |  padding追加
今回のPR  | デフォルト文字色 | 赤字そのまま | 赤字追加

【備考】
 - paddingはglobal/blogに設置........blog-blocksにpaddingを設定すると #76 同様１行目の開始位置がズレる現象が再び生じるのでpadding:0;に指定して回避してます。
- 赤字はblog/globalに記述する一方で文字色の指定のない時に適用されていたbody colorの—fgをblog-blocksで指定することでglobalで指定した赤字が不意に適用されてしまう現象を回避しています。

<img width="734" alt="スクリーンショット 2022-04-27 11 23 05" src="https://user-images.githubusercontent.com/24947347/165428802-578832e3-defb-4cd0-8e6f-e814a4e74c02.png">

- geist successの色指定がされていなかったことをたまたま見つけたので青にしてみました。
<img width="774" alt="スクリーンショット 2022-04-27 11 21 52" src="https://user-images.githubusercontent.com/24947347/165428837-872bf941-7a07-4018-a18e-950c6b09c83a.png">

