### PR TITLE
Fix color-block_text callout

### DIFF
--- a/src/styles/blog.module.css
+++ b/src/styles/blog.module.css
@@ -82,7 +82,6 @@
 }
 .post :global(p) {
   margin: 0.3rem 0;
-  color: var(--fg);
   font-size: 1rem;
   min-height: 1.8rem;
 }

--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -102,7 +102,6 @@
 }
 .callout div {
   margin: 0;
-  color: var(--fg);
   line-height: 1.2rem;
 }
 .callout div:first-child {


### PR DESCRIPTION
# 修正したこと
blockにcolorを装飾時のparagraph・calloutの装飾。


<img width="1053" alt="スクリーンショット 2022-05-07 1 09 11" src="https://user-images.githubusercontent.com/24947347/167180891-47b9f42d-4b4b-4b70-916f-a6cee552d745.png">
<img width="1090" alt="スクリーンショット 2022-05-07 1 12 47" src="https://user-images.githubusercontent.com/24947347/167180916-02c27ddc-6ade-4559-adef-67d2e4c65f7e.png">

# 現状まとめ



  | 一部文字色 | block文字色 | block文字色❌一部文字色 | block文字色❌一部背景色 | 一部背景色 | block背景色 | block背景色❌一部文字色 | block背景色❌一部背景色
-- | -- | -- | -- | -- | -- | -- | -- | --
テキスト | ⭕ | ❎ → ⭕ | ❎ → ⭕ | ❎ → ⭕ | ⭕ | ⭕ | ⭕ | ⭕
見出し | ⭕ | ❎ | ❎ | ❎ | ⭕ | ⭕ | ⭕ | ⭕
リスト | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕
ナンバーリスト | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕
コールアウト | ⭕ | ❎ → ⭕ | ❎ → ⭕ | ❎ → ⭕ | ⭕ | ⭕ | ⭕ | ⭕
引用 | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕ | ⭕


## 保留
見出し：同じように行うと<a>のCSSが出てくるのでやめてます。

見出しテキストを一時的に変更するシーンをあまりイメージできなかったので保留でいいかなといった感想です。