### PR TITLE
fix diagram-center_mermaid

### DIFF
--- a/src/styles/mermaid.module.css
+++ b/src/styles/mermaid.module.css
@@ -4,4 +4,5 @@
   padding: 0.8rem;
   background: #f1f1f1;
   border-radius: var(--radius);
+  text-align: center;
 }


### PR DESCRIPTION
Mermaidで作成した図(TB・BT)が左に寄ってしまう部分を中央に修正しました。

<img width="474" alt="スクリーンショット 2022-06-01 0 44 08" src="https://user-images.githubusercontent.com/24947347/171217671-dcd29287-d2a2-47ec-b77a-51ac6f62a70c.png">
👇
<img width="476" alt="スクリーンショット 2022-06-01 0 44 15" src="https://user-images.githubusercontent.com/24947347/171217683-d6f8d623-9f3f-4b50-b7ad-85a263b7312e.png">

