### PR TITLE
Fix displaying blocks in parent block

### DIFF
--- a/src/components/notion-block.tsx
+++ b/src/components/notion-block.tsx
@@ -284,7 +284,7 @@ const NumberedListItems = ({ blocks, level = 1 }) =>
       </li>
     ))
 
-const SyncedBlock = ({ block }) => block.SyncedBlock.Children.map((child: interfaces.Block) => <NotionBlock block={child} key={child.Id} />)
+const SyncedBlock = ({ block }) => <NotionBlocks blocks={block.SyncedBlock.Children} />
 
 const Toggle = ({ block }) => (
   <details className={styles.toggle}>

--- a/src/components/notion-block.tsx
+++ b/src/components/notion-block.tsx
@@ -294,7 +294,7 @@ const Toggle = ({ block }) => (
       ))}
     </summary>
     <div>
-      {block.Toggle.Children.map((child: interfaces.Block) => <NotionBlock block={child} key={child.Id} />)}
+      <NotionBlocks blocks={block.Toggle.Children} />
     </div>
   </details>
 )


### PR DESCRIPTION
Blocks consisted by multi-blocks, such as Bulleted List, Table, were not displayed in both Synced Blocks and Toggle.
So fixed them.
![スクリーンショット 2022-09-05 8 45 54](https://user-images.githubusercontent.com/1063435/188338148-ba3e1d4e-fda3-466f-b17a-bef64fbb9ec5.png)
