### PR TITLE
🐌 2ColumnList_respon640-1Column

### DIFF
--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -129,6 +129,14 @@
   flex: 1 1 180px;
   width: 180px;
 }
+@media (max-width: 640px) {
+  .columnList {
+    display: block;
+  }
+  .columnList > div {
+    width: 100%;
+  }
+}
 
 .bookmark {
   display: flex;
@@ -166,7 +174,7 @@
 .bookmark > a > div:first-child > div:nth-child(2) {
   font-size: 12px;
   line-height: 16px;
-  opacity: .8;
+  opacity: 0.8;
   height: 32px;
   overflow: hidden;
 }


### PR DESCRIPTION
# レスポンシブ対応で２カラムブロックを１カラムに

<img width="490" alt="スクリーンショット 2022-09-16 22 36 18" src="https://user-images.githubusercontent.com/24947347/190656397-9711f391-fa74-462c-986d-7d26731f0d6e.png">

<img width="762" alt="スクリーンショット 2022-09-16 22 36 27" src="https://user-images.githubusercontent.com/24947347/190656371-0b7c3488-80d5-4930-9428-e5860b4cbab9.png">

# 640px以上でも崩れがあります(未着手)
<img width="610" alt="スクリーンショット 2022-09-16 22 46 29" src="https://user-images.githubusercontent.com/24947347/190656690-6bb6136d-fb36-43d4-8fdd-cbdaec820ff5.png">


