### PR TITLE
🐌 Fix aspect ratio_video-youtube-block

### DIFF
--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -235,9 +235,16 @@
 .tweetEmbed div:first-child div:first-child {
   margin: auto;
 }
-
+.video .youtube {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 56.25%;
+}
 .video .youtube :first-child {
+  position: absolute;
   top: 0;
   right: 0;
   width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
# 画面サイズに合わせた表示
🐌　余白の黒がなくなりました


前：
<img width="634" alt="Screen Shot 2022-09-30 at 16 18 59" src="https://user-images.githubusercontent.com/24947347/193214557-b853333b-957f-4cb2-a41d-8312a0505b61.png">


後：
<img width="616" alt="Screen Shot 2022-09-30 at 16 19 37" src="https://user-images.githubusercontent.com/24947347/193214246-152be0b3-e4c6-4f19-b5c5-27ba0afba431.png">


---
# 参照記事
[【CSS】YouTube動画の比率（アスペクト比）を保持したまま埋め込む方法【レスポンシブ】](https://web-dev.tech/front-end/css/embed-youtube-iframe-with-proportion/#index_id2)

# 情報提供
@nuovotakaさん：https://twitter.com/nuovotaka/status/1575298125421748224
<img width="742" alt="Screen Shot 2022-09-30 at 16 28 20" src="https://user-images.githubusercontent.com/24947347/193215329-9aafcf62-3f8d-4936-94aa-299d04838c9a.png">
