### PR TITLE
🐌 Fix scroll in equation-block

### DIFF
--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -14,6 +14,10 @@
   text-align: center;
 }
 
+.equation {
+  overflow-x: scroll;
+}
+
 .code {
   display: block;
   width: 100%;


### PR DESCRIPTION
# 画面サイズ超過時にスクロール機能追加

本文が表示されるスペース(mainContent)の幅に収まるように修正しました。

前：
<img width="606" alt="Screen Shot 2022-09-30 at 16 36 45" src="https://user-images.githubusercontent.com/24947347/193217536-afa78c09-e865-4528-a2bd-8200ca189982.png">

後：
<img width="584" alt="Screen Shot 2022-09-30 at 16 37 07" src="https://user-images.githubusercontent.com/24947347/193217549-01c228b6-9fa4-46de-ad9f-ac9684fb7641.png">


