### PR TITLE
🐌 Fix inline-break in table-block

### DIFF
--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -116,7 +116,7 @@
 }
 .table th,
 .table td {
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .columnList {


### PR DESCRIPTION
# 修正前：改行ナシ+幅超なら横スクロール
<img width="590" alt="Screen Shot 2022-10-12 at 0 12 03" src="https://user-images.githubusercontent.com/24947347/195134079-f27bb57c-828e-45e2-8e12-b71cb9842cc8.png">

# 修正後：改行アリ+幅超過なら横スクロール
<img width="579" alt="Screen Shot 2022-10-12 at 0 12 21" src="https://user-images.githubusercontent.com/24947347/195134024-61676db9-e152-4d45-8958-ea40f444a016.png">

<img width="589" alt="Screen Shot 2022-10-12 at 0 14 07" src="https://user-images.githubusercontent.com/24947347/195134052-c70991d1-a4c7-4a2f-9408-56fd05668cfc.png">

