### PR TITLE
Fix og-image expiring after sharing URL on the social media

### DIFF
--- a/src/pages/api/og-image.ts
+++ b/src/pages/api/og-image.ts
@@ -1,0 +1,48 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import got from 'got'
+import { getPostBySlug } from '../../lib/notion/client'
+
+const ApiOgImage = async function(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.statusCode = 400
+    res.end()
+    return
+  }
+
+  const { slug: slugs } = req.query
+
+  if (!slugs) {
+    res.statusCode = 400
+    res.end()
+    return
+  }
+
+  const slug = slugs.toString()
+
+  try {
+    const post = await getPostBySlug(slug)
+    if (!post) {
+      throw new Error(`post not found. slug: ${slug}`)
+    }
+
+    if (!post.OGImage) {
+      res.statusCode = 404
+      res.end()
+      return
+    }
+
+    const { rawBody: image, headers: headers } = await got(post.OGImage)
+
+    res.setHeader('Content-Type', headers['content-type'])
+    res.setHeader('Cache-Control', 'public, s-maxage=86400, max-age=86400, stale-while-revalidate=86400')
+    res.write(image)
+    res.statusCode = 200
+    res.end()
+  } catch (e) {
+    console.log(e)
+    res.statusCode = 500
+    res.end()
+  }
+}
+
+export default ApiOgImage

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -125,7 +125,7 @@ const RenderPost = ({
       <DocumentHead
         title={post.Title}
         description={post.Excerpt}
-        urlOgImage={post.OGImage}
+        urlOgImage={NEXT_PUBLIC_URL && new URL(`/api/og-image?slug=${post.Slug}`, NEXT_PUBLIC_URL).toString()}
       />
 
       <div className={styles.mainContent}>


### PR DESCRIPTION
ref. https://twitter.com/otoyo0122/status/1590633336787308547

og-image was the S3 signed URL, so og-image wasn't seen after URL expired.
Now `/api/og-image` API is defined.
This API responds an image binary which has `content-type: image/png`.
Using the API in HTML head will fix this issue.