### PR TITLE
Change og-image API URL

### DIFF
--- a/src/pages/api/og-image/[slug].ts
+++ b/src/pages/api/og-image/[slug].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import got from 'got'
-import { getPostBySlug } from '../../lib/notion/client'
+import { getPostBySlug } from '../../../lib/notion/client'
 
 const ApiOgImage = async function(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -125,7 +125,7 @@ const RenderPost = ({
       <DocumentHead
         title={post.Title}
         description={post.Excerpt}
-        urlOgImage={NEXT_PUBLIC_URL && new URL(`/api/og-image?slug=${post.Slug}`, NEXT_PUBLIC_URL).toString()}
+        urlOgImage={NEXT_PUBLIC_URL && new URL(`/api/og-image/${post.Slug}`, NEXT_PUBLIC_URL).toString()}
       />
 
       <div className={styles.mainContent}>


### PR DESCRIPTION
ref https://github.com/otoyo/easy-notion-blog/pull/136

Some CDN ignores query parameters, so I change `slug` param from the query to the path.