### PR TITLE
Supports Date without time specification

### DIFF
--- a/lib/blog-helpers.ts
+++ b/lib/blog-helpers.ts
@@ -17,11 +17,13 @@ export const getTagBeforeLink = (tag: string, date: string) => {
 export const getDateStr = (date: string) => {
   const dt = new Date(date)
 
-  // Consider timezone
-  const elements = date.split('T')[1].split(/([+-])/)
-  if (elements.length > 1) {
-    const diff = parseInt(`${elements[1]}${elements[2]}`, 10)
-    dt.setHours(dt.getHours() + diff)
+  if(date.indexOf('T') !== -1){
+    // Consider timezone
+    const elements = date.split('T')[1].split(/([+-])/)
+    if (elements.length > 1) {
+      const diff = parseInt(`${elements[1]}${elements[2]}`, 10)
+      dt.setHours(dt.getHours() + diff)
+    }
   }
 
   const y = dt.getFullYear()


### PR DESCRIPTION
ブログ執筆時に時刻指定をしてなく日付だけ指定をしているNotionデータベースだとエラーが発生のでプルリクを出してみます。 

<img width="1028" alt="スクリーンショット 2022-12-30 14 04 45" src="https://user-images.githubusercontent.com/2968926/210037124-6bc8f3cc-6970-49a0-8c0c-61ac299fae32.png">
