### PR TITLE
Fix Internal Server Error when accessing a unfounded post

### DIFF
--- a/app/blog/[slug]/head.tsx
+++ b/app/blog/[slug]/head.tsx
@@ -5,12 +5,14 @@ import DocumentHead from '../../../components/document-head'
 const BlogSlugHead = async ({ params: { slug } }) => {
   const post = await getPostBySlug(slug)
 
-  return (
+  return post ? (
     <DocumentHead
       title={post.Title}
       description={post.Excerpt}
       path={getBlogLink(post.Slug)}
     />
+  ) : (
+    <DocumentHead/>
   )
 }
 


### PR DESCRIPTION
存在しないポストへアクセスすると 500 エラーが起きていたので修正PRです。

## 概要
https://easy-notion-blog-otoyo.vercel.app/blog/hoge のような存在しない slug へアクセスすると Internal Server Error が発生する。

`app/blog/[slug]/page.tsx` では `post` が見つからなかった場合リダイレクトが走る仕様になっているが、 `app/blog/[slug]/head.tsx` では `post` が見つからない場合も `post.Title` 等で呼び出しが起こるため以下のようなエラーが発生する。

```
2023-01-08T08:13:40.693Z	3abfe53b-a7f8-4446-961c-7294ad96b3bc	ERROR	TypeError: Cannot read properties of null (reading 'Title')
    at BlogSlugHead (/var/task/.next/server/app/blog/[slug]/page.js:440:21)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## 対応内容
`app/blog/[slug]/head.tsx` において、 `post` が見つからなかった場合は空の `<DocumentHead/>` を返すように変更しました。