### PR TITLE
Update README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,15 +62,20 @@ easy-notion-blog を使えばあっという間に Notion Blog を始めるこ�
 
 - Node.js v16 もしくはそれ以上
 - [Yarn](https://yarnpkg.com/getting-started)
+- [direnv](https://github.com/direnv/direnv)
 
 ### 手順
 
 1. このリポジトリをフォークしてローカルに clone します
-2. プロジェクトルートに `.env.local` ファイルを作成し下記のように環境変数を書き込みます
+2. プロジェクトルートで direnv を使って下記の環境変数を設定します
 
 ```sh
-NOTION_API_SECRET=<YOUR_NOTION_API_SECRET>
-DATABASE_ID=<YOUR_DATABASE_ID>
+direnv edit .
+```
+
+```sh
+export NOTION_API_SECRET=<YOUR_NOTION_API_SECRET>
+export DATABASE_ID=<YOUR_DATABASE_ID>
 ```
 
 3. 依存関係をインストールしローカルサーバーを起動します

--- a/README.md
+++ b/README.md
@@ -60,15 +60,20 @@ See also users' sites from [wiki](https://github.com/otoyo/easy-notion-blog/wiki
 
 - Node.js v16 or higher
 - [Yarn](https://yarnpkg.com/getting-started)
+- [direnv](https://github.com/direnv/direnv)
 
 ### Steps
 
 1. Fork this repo from "Fork" button and clone it into your local workspace.
-2. Create `.env.local` file just under the project root and put your environment variables as follows:
+2. Set the following environment variables with direnv in the project root.
 
 ```sh
-NOTION_API_SECRET=<YOUR_NOTION_API_SECRET>
-DATABASE_ID=<YOUR_DATABASE_ID>
+direnv edit .
+```
+
+```sh
+export NOTION_API_SECRET=<YOUR_NOTION_API_SECRET>
+export DATABASE_ID=<YOUR_DATABASE_ID>
 ```
 
 3. Install dependencies and start local server.


### PR DESCRIPTION
Scripts under `scripts/` needs `NOTION_API_SECRET` and `DATABASE_ID` but `.env*` is not read at the time because the scripts is not Next.js app.
So environment variables setting is needed.